### PR TITLE
root pandas is now automatically dropping columns...

### DIFF
--- a/root_pandas/readwrite.py
+++ b/root_pandas/readwrite.py
@@ -154,7 +154,7 @@ def read_root(paths, key=None, columns=None, ignore=None, chunksize=None, where=
         col_names = np.array(arr.dtype.names)
         good_names = col_names[good_cols]
         bad_names = col_names[~good_cols]
-        if bad_names:
+        if not bad_names.size == 0:
             warnings.warn("Ignored the following non-scalar branches: {bad_names}"
                           .format(bad_names=", ".join(bad_names)), UserWarning)
         return arr[good_names]

--- a/root_pandas/readwrite.py
+++ b/root_pandas/readwrite.py
@@ -151,12 +151,13 @@ def read_root(paths, key=None, columns=None, ignore=None, chunksize=None, where=
     def remove_high_dimensions(arr):
         allowed_dimensions = [0]
         first_row = arr[0]
-        good_cols = [ True if x.ndim in allowed_dimensions else False for x in first_row]
+        good_cols = [True if x.ndim in allowed_dimensions else False for x in first_row]
         col_names = np.array(list(arr.dtype.names))
         good_names = col_names[np.array(good_cols)]
-        bad_names = col_names[np.array([ not x for x in good_cols])]
+        bad_names = col_names[np.array([not x for x in good_cols])]
         for bad_name in bad_names:
-            warnings.warn("Dropped {bad_name} branch because dimension is unfit for DataFrame".format(bad_name=bad_name), UserWarning)
+            warnings.warn("Dropped {bad_name} branch because dimension is unfit for DataFrame"
+                          .format(bad_name=bad_name), UserWarning)
         return arr[good_names]
 
     if chunksize:


### PR DESCRIPTION
 that have multidimensional entries. This is done after the optional flattening.

If you have suggestions to make the code prettier or faster, I am all ears.
Do you think arr = arr[good_names] might be a performance bottleneck?

How would I measure this?

And why does the warning message print its own line of code?