### PR TITLE
switch to ROOT conda builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,37 @@
+#sudo: false
 # travis-ci.org build & test configuration
 language: python
-python:
-    - "2.7"
-    - "3.4"
-env:
-    - ROOT=5.34.18
-    - ROOT=master # COVERAGE=1
-install: source ci/install.sh
+
+matrix:
+    include:
+        - python: 2.7
+          env: PYTHON=2.7 ROOT=5.34.32
+        - python: 2.7
+          env: PYTHON=2.7 ROOT=6.04
+        - python: 3.4
+          env: PYTHON=3.4 ROOT=5.34.32
+        - python: 3.4
+          env: PYTHON=3.4 ROOT=6.04
+    allow_failures:
+        - python: 3.4
+#install: source ci/install.sh
+install:
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a # Useful for debugging any issues with conda
+  - conda config --add channels http://conda.anaconda.org/NLeSC  
+  - conda config --set show_channel_urls yes
+  - conda create -q -n testenv python=${PYTHON} root=${ROOT} rootpy pandas nose
+  - source activate testenv
+
 script: nosetests
 #after_success:
 #    - time coveralls
-cache: apt
-sudo: true
 notifications:
     email: false


### PR DESCRIPTION
 Integrate Travis with ROOT conda builds, rather than the externally-hosted binaries (which fail lately):
* rootpy, root-numpy dependency is picked up from conda
* Added python 3 in the matrix, just because we can.