### PR TITLE
Use noexpand: prefix for formula branches.

### DIFF
--- a/root_pandas/readwrite.py
+++ b/root_pandas/readwrite.py
@@ -100,6 +100,9 @@ def read_root(paths, key=None, columns=None, ignore=None, chunksize=None, where=
         The key of the tree to load.
     columns: str or sequence of str
         A sequence of shell-patterns (can contain *, ?, [] or {}). Matching columns are read.
+        The columns beginning with `noexpand:` are not interpreted as shell-patterns,
+        allowing formula columns such as `noexpand:2*x`. The column in the returned DataFrame
+        will not have the `noexpand:` prefix.
     ignore: str or sequence of str
         A sequence of shell-patterns (can contain *, ?, [] or {}). All matching columns are ignored (overriding the columns argument).
     chunksize: int

--- a/tests/test.py
+++ b/tests/test.py
@@ -168,3 +168,23 @@ def test_drop_nonscalar_columns():
     assert(np.all(df.d.values == np.array([True, False])))
 
     os.remove(path)
+
+def test_noexpand_prefix():
+    xs = np.array([1, 2, 3])
+    df = pd.DataFrame({'x': xs})
+    df.to_root('tmp.root')
+
+    # Not using the prefix should throw, as there's no matching branch name
+    try:
+        df = read_root('tmp.root', columns=['2*x'])
+    except ValueError:
+        pass
+    else:
+        assert False
+
+    # Could also use TMath::Sqrt here
+    df = read_root('tmp.root', columns=['noexpand:2*sqrt(x)'])
+    # Note that the column name shouldn't have the noexpand prefix
+    assert np.all(df['2*sqrt(x)'].values == 2*np.sqrt(xs))
+
+    os.remove('tmp.root')


### PR DESCRIPTION
`root_numpy` supports branch names to be formulas, such as `2*sqrt(x)`, which are parsed by ROOT’s TFormula class.

The use of `*` by `root_pandas` for branch name matching conflicted with this behaviour. This commit adds the `NOEXPAND_PREFIX` string, which causes column names to skip the branch name matching mechanisms.

See #14 for more.