### PR TITLE
Somehow conda no longer has the CONDA_ENV_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - conda config --add channels http://conda.anaconda.org/NLeSC  
   - conda config --set show_channel_urls yes
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} rootpy pandas nose
+  - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
 
 script: nosetests


### PR DESCRIPTION
See also: https://github.com/remenska/conda-builds/issues/1 and https://github.com/rootpy/rootpy/pull/689#issuecomment-229604903
This is why the tests were failing.
For now it's easiest to just set it manually.