### PR TITLE
Require pandas >= 0.18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='root_pandas',
       license='MIT',
       install_requires=[
           'numpy',
-          'pandas',
+          'pandas>=0.18.0',
           'root_numpy',
       ],
       packages=['root_pandas'],


### PR DESCRIPTION
According to pandas documentation: `RangeIndex is a sub-class of Int64Index added in version 0.18.0`
RangeIndex is used in root_pandas.